### PR TITLE
Update pktgen version to work with dpdk 17.08

### DIFF
--- a/openNetVM-Scripts/pktgen-config.lua
+++ b/openNetVM-Scripts/pktgen-config.lua
@@ -1,0 +1,79 @@
+--                    openNetVM
+--      https://github.com/sdnfv/openNetVM
+--
+-- BSD LICENSE
+--
+-- Copyright(c)
+--          2015-2016 George Washington University
+--          2015-2016 University of California Riverside
+-- All rights reserved.
+
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions
+-- are met:
+
+-- Redistributions of source code must retain the above copyright
+-- notice, this list of conditions and the following disclaimer.
+-- Redistributions in binary form must reproduce the above copyright
+-- notice, this list of conditions and the following disclaimer in
+-- the documentation and/or other materials provided with the
+-- distribution.
+-- The name of the author may not be used to endorse or promote
+-- products derived from this software without specific prior
+-- written permission.
+
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+-- "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+-- LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+-- A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+-- OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+-- SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+-- LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+-- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+-- THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-- Change any of the settings below to configure Pktgen-DPDK
+
+
+--package.path = package.path ..";?.lua;test/?.lua;app/?.lua;"
+
+-- A list of the test script for Pktgen and Lua.
+-- Each command somewhat mirrors the pktgen command line versions.
+-- A couple of the arguments have be changed to be more like the others.
+
+printf("Lua Version      : %s\n", pktgen.info.Lua_Version);
+printf("Pktgen Version   : %s\n", pktgen.info.Pktgen_Version);
+printf("Pktgen Copyright : %s\n", pktgen.info.Pktgen_Copyright);
+
+prints("pktgen.info", pktgen.info);
+
+printf("Port Count %d\n", pktgen.portCount());
+printf("Total port Count %d\n", pktgen.totalPorts());
+
+
+-- set up a mac address to set flow to 
+--  
+-- TO DO LIST:
+--
+-- Please update this part with the destination mac address, source and destination ip address you would like to sent packets to 
+
+pktgen.set_mac("0", "90:e2:ba:5e:73:6c"); 
+pktgen.set_ipaddr("0", "dst", "10.11.1.17");
+pktgen.set_ipaddr("0", "src", "10.11.1.16");
+
+
+
+pktgen.set_proto("all", "udp");
+pktgen.set_type("all", "ipv4");
+
+pktgen.set("all", "size", 64)
+pktgen.set("all", "burst", 32);
+pktgen.set("all", "sport", 1234);
+pktgen.set("all", "dport", 1234);
+pktgen.set("all", "count", 100000000);
+pktgen.set("all", "rate",100);
+
+pktgen.vlan_id("all", "start", 1);
+

--- a/openNetVM-Scripts/run-pktgen.sh
+++ b/openNetVM-Scripts/run-pktgen.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+#                    openNetVM
+#      https://github.com/sdnfv/openNetVM
+#
+# BSD LICENSE
+#
+# Copyright(c)
+#          2015-2016 George Washington University
+#          2015-2016 University of California Riverside
+#          2010-2014 Intel Corporation.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+# Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in
+# the documentation and/or other materials provided with the
+# distribution.
+# The name of the author may not be used to endorse or promote
+# products derived from this software without specific prior
+# written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# These are the interfaces that you do not want to use for Pktgen-DPDK
+BLACK_LIST="-b 0000:05:00.0 -b 0000:05:00.1"
+
+# Path variable for pktgen
+PKTGENBUILD="../app/app/x86_64-native-linuxapp-gcc/app/pktgen"
+
+# Path for pktgen config
+PKTGENCONFIG="./pktgen-config.lua"
+
+if [[ $1 -eq 0 ]] ; then
+	echo "pass an argument for port count"
+	echo "example usage: sudo bash run-pktgen.sh 1"
+	exit 0
+fi
+
+echo "Start pktgen"
+
+if [ $1 = 2 ]; then
+
+sudo $PKTGENBUILD -c ffff -n 3 $BLACK_LIST -- -p 0x1 -P -m "[1:2].0, [3:4].1" -f $PKTGENCONFIG
+
+else
+
+sudo $PKTGENBUILD -c ffff -n 3 $BLACK_LIST -- -p 0x3 -P -m "[4:8].0" -f $PKTGENCONFIG
+
+fi
+
+echo "Pktgen done"

--- a/openNetVM-Scripts/run-pktgen.sh
+++ b/openNetVM-Scripts/run-pktgen.sh
@@ -41,10 +41,10 @@
 BLACK_LIST="-b 0000:05:00.0 -b 0000:05:00.1"
 
 # Path variable for pktgen
-PKTGENBUILD="../app/app/x86_64-native-linuxapp-gcc/app/pktgen"
+PKTGENBUILD="./app/app/x86_64-native-linuxapp-gcc/app/pktgen"
 
 # Path for pktgen config
-PKTGENCONFIG="./pktgen-config.lua"
+PKTGENCONFIG="./openNetVM-Scripts/pktgen-config.lua"
 
 if [[ $1 -eq 0 ]] ; then
 	echo "pass an argument for port count"
@@ -56,11 +56,11 @@ echo "Start pktgen"
 
 if [ $1 = 2 ]; then
 
-sudo $PKTGENBUILD -c ffff -n 3 $BLACK_LIST -- -p 0x1 -P -m "[1:2].0, [3:4].1" -f $PKTGENCONFIG
+(cd ../ && sudo $PKTGENBUILD -c ffff -n 3 $BLACK_LIST -- -p 0x1 -P -m "[1:2].0, [3:4].1" -f $PKTGENCONFIG)
 
 else
 
-sudo $PKTGENBUILD -c ffff -n 3 $BLACK_LIST -- -p 0x3 -P -m "[4:8].0" -f $PKTGENCONFIG
+(cd ../ && sudo $PKTGENBUILD -c ffff -n 3 $BLACK_LIST -- -p 0x3 -P -m "[4:8].0" -f $PKTGENCONFIG)
 
 fi
 


### PR DESCRIPTION
Pull most recent code from dpdk-pktgen master to work with openNetVM's version of DPDK.

__Problem__: pktgen version was outdated and relied on older APIs that DPDK had since moved away from. This produced compile errors.
__Solution:__ Pull most recent code from pktgen upstream. 