### PR TITLE
Fix run-pktgen script pktgen path

### DIFF
--- a/openNetVM-Scripts/run-pktgen.sh
+++ b/openNetVM-Scripts/run-pktgen.sh
@@ -41,7 +41,7 @@
 BLACK_LIST="-b 0000:05:00.0 -b 0000:05:00.1"
 
 # Path variable for pktgen
-PKTGENBUILD="./app/app/x86_64-native-linuxapp-gcc/app/pktgen"
+PKTGENBUILD="./app/x86_64-native-linuxapp-gcc/pktgen"
 
 # Path for pktgen config
 PKTGENCONFIG="./openNetVM-Scripts/pktgen-config.lua"


### PR DESCRIPTION
This is a fix to an incorrect path in the ONVM `run-pktgen.sh` script.

**Summary:**
Running
```
openNetVM/tools/Pktgen/pktgen-dpdk/openNetVM-Scripts$ sudo bash run-pktgen.sh 1
```
results in the following error:
```
sudo: ./app/app/x86_64-native-linuxapp-gcc/app/pktgen: command not found
```

This fix updates the specified path so that this message does not appear and pktgen can run.

**Test Plan:**
It was verified that making this edit to the script on a CloudLab instance with the `onvm-18.05` profile prevents this command not found error.

**Reviewers:** @nks5295 

**Subscribers:** @rskennedy @koolzz @twood02 